### PR TITLE
Updating node-ecstatic package to latest to get rid of vulnerability

### DIFF
--- a/covalent-e2e-coverage/README.md
+++ b/covalent-e2e-coverage/README.md
@@ -21,6 +21,7 @@ Read the [was-tested Code coverage proxy](https://glebbahmutov.com/blog/code-cov
 To instrument e2e coverage for a Typescript project do the following:
 
 * Clone this repository
+* cd covalent-e2e-coverage
 * Startup the covalent-e2e-coverage proxy in this repo by running `npm run start`
 * Checkout another repo that has e2e tests in it
 * Edit the package.json in the other repo to run in production mode, but with source maps turned on:

--- a/covalent-e2e-coverage/package.json
+++ b/covalent-e2e-coverage/package.json
@@ -12,7 +12,7 @@
   "contributors": [],
   "dependencies": {
     "check-more-types": "2.20.2",
-    "ecstatic": "1.4.0",
+    "ecstatic": "3.1.1",
     "http-proxy": "1.13.2",
     "istanbul": "0.4.3",
     "lazy-ass": "1.4.0",


### PR DESCRIPTION
## Description
Updated package.json with new version of node-ecstatic to remove this warning:

https://github.com/Teradata/covalent-tools/network/dependencies

We found a potential security vulnerability in one of your dependencies.
The ecstatic dependency defined in package.json has a known high severity security vulnerability in version range < 2.0.0 and should be updated.

### What's included?
- package.json

#### Test Steps
- [ ] Checkout this branch feature/coverage-e2e
- [ ] cd covalent-e2e-coverage
- [ ] npm i
- [ ] startup the covalent-e2e-coverage proxy in this branch by running `npm run start`
- [ ] Checkout another repo that has e2e tests in it
- [ ] Edit the package.json in the other repo to run in production mode, but with source maps turned on:
```
"scripts": {
"serve:prod": "node --max_old_space_size=5048 ./node_modules/.bin/ng serve --aot --prod --sourcemap=true --build-optimizer --proxy-config proxy.conf.json",
...
}
```
- [ ] start up this repo with e2e tests in it with the command `npm run serve:prod`
- [ ] Edit the package.json of the repo that has the e2e tests in it to point to the covalent-e2e-coverage proxy instead:
```
"scripts": {
"e2e": "ng e2e -pc proxy.conf.json --no-serve --base-href=http://localhost:5050",
...
}
```
- [ ] run the e2e tests, `npm run e2e`
- [ ] After completed either hit the genreport endpoint: http://localhost:5050/__genreport
or run the npm script to generate the report: `npm run genreport`
- [ ] In the browser go to: http://localhost:5050/__report/
- [ ] See Coverage Report
- [ ] Click down into links and see Typescript files
